### PR TITLE
Added support for decimal media queries

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,8 +79,8 @@ const mediaQueriesSplitter = {
                             ruleMediaMax = null;
 
                         if (_rule.type === 'media' && _rule.media) {
-                            ruleMediaMin = _rule.media.match(/\(min-width:\s*([0-9]+)px\)/);
-                            ruleMediaMax = _rule.media.match(/\(max-width:\s*([0-9]+)px\)/);
+                            ruleMediaMin = _rule.media.match(/\(min-width:\s*([0-9]+)(\.[0-9]+)?px\)/);
+                            ruleMediaMax = _rule.media.match(/\(max-width:\s*([0-9]+)(\.[0-9]+)?px\)/);
 
                             if ((ruleMediaMin && ruleMediaMin[1]) || (ruleMediaMax && ruleMediaMax[1])) {
                                 isMediaWidthRule = true;


### PR DESCRIPTION
Added optional decimal value to the regex that checks for a media query match. This allows media queries with decimal values to be caught by the plugin. This is relevant since browser zoom may result in decimal px values for screen size.